### PR TITLE
Fix mobile creative commons logos for mobile

### DIFF
--- a/_sass/jekyll-theme-cayman.scss
+++ b/_sass/jekyll-theme-cayman.scss
@@ -462,9 +462,16 @@ ul.fa-ul li a i {
 .creative-commons-logos {
   font-size: 96px;
 
+  @include small { 
+    font-size: 64px;
+  }
+
   i {
     color: $header-bg-color;
-    padding: 20px;
+
+    @include large {
+      padding: 20px;
+    }
   }
 }
 


### PR DESCRIPTION
Downsize logos for small screen, only use padding for large